### PR TITLE
Add support for defining additional methods

### DIFF
--- a/spec/dataclass_spec.cr
+++ b/spec/dataclass_spec.cr
@@ -13,6 +13,15 @@ end
 dataclass B{id : Int32} < A
 dataclass C{id : Int32}
 dataclass Compound{id : String, b : B, c : C}
+dataclass WithBlock{id : Int32} < A do
+  def foo
+    "bar"
+  end
+
+  def tick
+    "super: #{super}"
+  end
+end
 
 dataclass WithTypeParam(T){field : T}
 
@@ -161,5 +170,18 @@ describe DataClass do
       # do nothing
     else fail("should have matched the above")
     end
+  end
+
+  it "supports defining class bodies in blocks" do
+    WithBlock.new(id: 10).foo.should eq("bar")
+  end
+
+  it "supports inheritance with block" do
+    WithBlock.new(id: 10).is_a?(A).should eq(true)
+    WithBlock.new(id: 10).is_a?(B).should eq(false)
+  end
+
+  it "supports calling super from block" do
+    WithBlock.new(id: 10).tick.should eq("super: called_tick")
   end
 end

--- a/src/dataclass.cr
+++ b/src/dataclass.cr
@@ -15,10 +15,10 @@ macro dataclass(class_def)
       getter {{key.var}}
     {% end %}
 
-    def initialize({% for key in literal %}
-      @{{key}},
-    {% end %})
+    def initialize({{*literal.map { |key| "@#{key}".id }}})
     end
+
+    {{yield}}
 
     def_equals_and_hash({% for key in literal %}@{{key.var}},{% end %})
 


### PR DESCRIPTION
Additional methods can now optionally be defined in a code block.

- Updated dataclass.cr to yield code block
- Updated spec/dataclass_spec.cr to test changes
- Updated README.md
  - Added an example
  - Removed limitation from "Known Limitations"
- Cleaned `initialize` definition in dataclass.cr